### PR TITLE
Edit links field to the correct value JSON file

### DIFF
--- a/dappnode_package.json
+++ b/dappnode_package.json
@@ -12,7 +12,7 @@
   ],
   "categories": ["Storage", "Communications"],
   "links": {
-    "api": "http://bee.dappnode:8080/"
+    "api": "http://bee.dappnode:1633/"
   },
   "requirements": {
     "minimumDappnodeVersion": "0.2.29"


### PR DESCRIPTION
Fixing the little error of the field links of the file dappnode_package.json. where it said the API port was 8080 when it is 1633.