### PR TITLE
Include critical files for backup

### DIFF
--- a/dappnode_package.json
+++ b/dappnode_package.json
@@ -31,6 +31,10 @@
     {
       "name": "keys",
       "path": "/home/bee/.bee/keys"
+    },
+    {
+      "name": "statestore",
+      "path": "/home/bee/.bee/statestore"
     }
   ]
 }


### PR DESCRIPTION
Keys and statestore are needed for backup, we added the path in the manifest.
It has been tested and it works.
fix #20 